### PR TITLE
getTagName now is getting the node element tag

### DIFF
--- a/src/dragon/views/base.js
+++ b/src/dragon/views/base.js
@@ -344,7 +344,7 @@ class DragonBaseView {
     var el = document.createElement('div')
     el.innerHTML = template
 
-    return el.firstChild.tagName.toLowerCase()
+    return el.firstElementChild.tagName.toLowerCase()
 
   }
 


### PR DESCRIPTION
now we are getting the node element instead of text element 
http://prntscr.com/8picfb
the nodeElement  has the tagName attr :smiley: